### PR TITLE
refactor: modify the handling of indexes on table "..."

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /lua
 /lua_modules
 /.luarocks
+src/test.lua

--- a/src/main.lua
+++ b/src/main.lua
@@ -38,19 +38,15 @@ end
 function add(...)
 	local args = ...
 	
-	if #args ~= 3 and #args ~= 4 then
+	if #args ~= 2 and #args ~= 3 then
 		--[[
 			args = {
-				[1] = add
+				[1] = credential
 				or
-				[1] = add,
-				[2] = credential
-				or
-				[1] = add,
-				[2] = credential,
-				[3] = gpg_id,
-				[4] = bla,
-				[5] = bla
+				[1] = credential,
+				[2] = gpg_id,
+				[3] = bla,
+				[4] = bla
 				et cetera
 			}
 		]]--
@@ -60,17 +56,16 @@ function add(...)
 			)
 	end
 	
-	if #args == 3 then
+	if #args == 2 then
 		--[[
 			args = {
-				[1] = add,
-				[2] = credential,
-				[3] = gpg_id
+				[1] = credential,
+				[2] = gpg_id
 			}
 		]]--
 		
-		local credential = args[2]
-		local gpg_id = args[3]
+		local credential = args[1]
+		local gpg_id = args[2]
 		local password = ''
 		local credential_path = BRUCE_VAULT_PATH .. credential
 		
@@ -85,19 +80,18 @@ function add(...)
 		return showCredentialStatus(credential_path)
 	end
 	
-	if #args == 4 then
+	if #args == 3 then
 		--[[
 			args = {
-				[1] = add,
-				[2] = --print, -p or --open-editor, -op,
-				[3] = credential,
-				[4] = gpg_id
+				[1] = --print, -p or --open-editor, -op,
+				[2] = credential,
+				[3] = gpg_id
 			}		
 		]]--
 
-		local option = args[2]
-		local credential = args[3]
-		local gpg_id = arg[4]
+		local option = args[1]
+		local credential = args[2]
+		local gpg_id = arg[3]
 		local credential_path = BRUCE_VAULT_PATH .. credential
 		
 		if option == '--print' or option == '-p' then
@@ -151,7 +145,9 @@ commands = {
 function run(...)
 	local command = commands[table.unpack(...)]
 	if command then
-		return command(...)
+		local args = ...
+		table.remove(args, 1)
+		return command(args)
 	end
 	return commands.help()
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,5 +1,3 @@
--- gpg --decrypt /tmp/.bruce-vault/credential.gpg | cat
-
 local BRUCE_VAULT_PATH = '/tmp/.bruce-vault/'
 local GPG_IDS_FILE = BRUCE_VAULT_PATH .. '.gpg-history'
 
@@ -118,8 +116,14 @@ function add(...)
 	end
 end
 
-function addf(...)
-	print('addf')
+function show(...)
+	local credential = ...
+	local credential = credential[1]
+	os.execute(string.format('gpg --decrypt %s%s.gpg | cat', BRUCE_VAULT_PATH, credential))
+end
+
+function ls()
+	os.execute('tree -a -C '..BRUCE_VAULT_PATH)
 end
 
 function help(...)
@@ -131,6 +135,10 @@ function help(...)
 	Add a credential into Bruce Vault.
 	bruce help ->
 	Show this help message.
+	bruce show <credential> ->
+	Show the data of a specific credential
+	bruce ls ->
+	Show all credentials into bruce vault
 	]]	
 	)
 end
@@ -139,7 +147,8 @@ commands = {
 	['init'] = init,
 	['help'] = help,
 	['add'] = add,
-	['addf'] = addf
+	['show'] = show,
+	['ls'] = ls,
 }
 
 function run(...)


### PR DESCRIPTION
In the run function, the treatment of indexes in the "..." table was changed because we will no longer ignore the first index in the other functions. The index always corresponded to the command that was going to be executed. Therefore, within the command function itself, it was irrelevant to have the command name as the first index.